### PR TITLE
feat: add support for path style requests

### DIFF
--- a/api/src/main/java/io/github/linktosriram/s3lite/api/region/Region.java
+++ b/api/src/main/java/io/github/linktosriram/s3lite/api/region/Region.java
@@ -75,13 +75,22 @@ public final class Region {
     public static Region of(final String regionName, final URI endpoint) {
         return new Region(regionName, endpoint);
     }
+    public static Region of(final String regionName, final URI endpoint, final boolean usePathStyleRequests) {
+        return new Region(regionName, endpoint, usePathStyleRequests);
+    }
 
     private final String regionName;
     private final URI endpoint;
+    private final boolean usePathStyleRequests;
 
-    private Region(final String regionName, final URI endpoint) {
+    private Region(final String regionName, final URI endpoint, final boolean usePathStyleRequests) {
         this.regionName = regionName;
         this.endpoint = endpoint;
+        this.usePathStyleRequests = usePathStyleRequests;
+    }
+
+    private Region(final String regionName, final URI endpoint) {
+        this(regionName, endpoint, false);
     }
 
     public String getRegionName() {
@@ -90,6 +99,10 @@ public final class Region {
 
     public URI getEndpoint() {
         return endpoint;
+    }
+
+    public boolean getUsePathStyleRequests() {
+        return usePathStyleRequests;
     }
 
     public static Region fromString(final String regionName) {
@@ -104,6 +117,7 @@ public final class Region {
         return "Region{" +
             "regionName='" + regionName + '\'' +
             ", endpoint=" + endpoint +
+            ", usePathStyleRequests=" + usePathStyleRequests +
             '}';
     }
 }


### PR DESCRIPTION
Hi,
this adds [path style requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access). Which can be useful for 3rd party implementations like [MinIO](https://min.io/) or during development when hostname based requests are too much hassle.

It can be used like this:
```java
S3Client client = new DefaultS3ClientBuilder()
  .credentialsProvider(() -> AwsBasicCredentials.create("access-key", "secret-access-key"))
  .region(Region.of("us-east-1", "http://localhost:9000", true)) // connect to MinIO with path style requests
  .httpClient(ApacheSdkHttpClient.defaultClient()) // Or use URLConnectionSdkHttpClient
  .build();
```

Closes #2 