### PR TITLE
ApacheSdkHttpClient improvements

### DIFF
--- a/http-client-apache/src/main/java/io/github/linktosriram/s3lite/http/apache/ApacheSdkHttpClient.java
+++ b/http-client-apache/src/main/java/io/github/linktosriram/s3lite/http/apache/ApacheSdkHttpClient.java
@@ -145,7 +145,12 @@ public class ApacheSdkHttpClient implements SdkHttpClient {
     }
 
     private static void addHeaders(final Map<String, List<String>> headers, final HttpMessage request) {
-        headers.forEach((name, value) -> request.addHeader(name, join(",", value)));
+        headers.forEach((name, value) -> {
+            // apache client insists on adding content-length header itself based on HttpEntity.getContentLength
+            if (!"content-length".equalsIgnoreCase(name)) {
+                request.addHeader(name, join(",", value));
+            }
+        });
     }
 
     private static Map<String, List<String>> fromHeaders(final Header[] headers) {

--- a/http-client-apache/src/main/java/io/github/linktosriram/s3lite/http/apache/ApacheSdkHttpClient.java
+++ b/http-client-apache/src/main/java/io/github/linktosriram/s3lite/http/apache/ApacheSdkHttpClient.java
@@ -13,7 +13,6 @@ import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 
@@ -133,15 +132,17 @@ public class ApacheSdkHttpClient implements SdkHttpClient {
     }
 
     private static URI getUri(final ImmutableRequest request) throws URISyntaxException {
-        final Map<String, List<String>> parameters = request.getParameters();
-        final URIBuilder builder = new URIBuilder(request.getEndpoint())
-            .setPath(request.getResourcePath());
+        final StringBuilder builder = new StringBuilder()
+            .append(request.getEndpoint())
+            .append(request.getResourcePath());
 
-        if (!parameters.isEmpty()) {
-            builder.setCustomQuery(toQueryString(parameters));
+        final String queryString = toQueryString(request.getParameters());
+
+        if (!queryString.isEmpty()) {
+            builder.append("?").append(queryString);
         }
 
-        return builder.build();
+        return URI.create(builder.toString());
     }
 
     private static void addHeaders(final Map<String, List<String>> headers, final HttpMessage request) {


### PR DESCRIPTION
Hi,
this contains some fixes and improvements for the apache client impl:

* It implements streaming PUT requests
* Fixes a bug where the apache client did not accept an existing content-length header on requests
* Fixes a bug which caused the prefix query parameter for ListObjectsV2 requests to be url encoded twice, altering its meaning