### PR TITLE
ListObjectsV2 improvements

### DIFF
--- a/core/src/main/java/io/github/linktosriram/s3lite/core/client/DefaultS3Client.java
+++ b/core/src/main/java/io/github/linktosriram/s3lite/core/client/DefaultS3Client.java
@@ -81,12 +81,11 @@ final class DefaultS3Client implements S3Client {
             return response.getResponseBody()
                 .map(inputStream -> {
                     try (final InputStream input = inputStream) {
-                        return IOUtils.toByteArray(input);
+                        return new ListObjectsV2ResponseMapper().apply(input);
                     } catch (final IOException e) {
                         throw new UncheckedIOException(e);
                     }
                 })
-                .map(bytes -> new ListObjectsV2ResponseMapper().apply(bytes))
                 .orElseThrow(() -> new RuntimeException("No response body found"));
         } else {
             throw handleErrorResponse(response);

--- a/core/src/main/java/io/github/linktosriram/s3lite/core/mapper/ListObjectsV2ResponseMapper.java
+++ b/core/src/main/java/io/github/linktosriram/s3lite/core/mapper/ListObjectsV2ResponseMapper.java
@@ -164,10 +164,10 @@ public class ListObjectsV2ResponseMapper implements ResponseMapper<ListObjectsV2
                         } else if (bETag) {
                             s3Object = s3Object.eTag(reader.getText());
                         } else if (bOwner) {
-                            if (bContents) {
-                                s3Object = s3Object.owner(owner.build());
-                            } else if (bCommonPrefixes) {
-                                commonPrefix = commonPrefix.owner(owner.build());
+                            if (bDisplayName) {
+                                owner = owner.displayName(reader.getText());
+                            } else if (bID) {
+                                owner = owner.id(reader.getText());
                             }
                         } else if (bKey) {
                             s3Object = s3Object.key(reader.getText());
@@ -177,10 +177,6 @@ public class ListObjectsV2ResponseMapper implements ResponseMapper<ListObjectsV2
                             s3Object = s3Object.size(Long.valueOf(reader.getText()));
                         } else if (bStorageClass) {
                             s3Object = s3Object.storageClass(reader.getText());
-                        } else if (bDisplayName) {
-                            owner = owner.displayName(reader.getText());
-                        } else if (bID) {
-                            owner = owner.id(reader.getText());
                         }
                         break;
 
@@ -242,6 +238,11 @@ public class ListObjectsV2ResponseMapper implements ResponseMapper<ListObjectsV2
 
                             case "Owner":
                                 bOwner = false;
+                                if (bContents) {
+                                    s3Object = s3Object.owner(owner.build());
+                                } else if (bCommonPrefixes) {
+                                    commonPrefix = commonPrefix.owner(owner.build());
+                                }
                                 break;
 
                             case "Key":

--- a/core/src/main/java/io/github/linktosriram/s3lite/core/mapper/ListObjectsV2ResponseMapper.java
+++ b/core/src/main/java/io/github/linktosriram/s3lite/core/mapper/ListObjectsV2ResponseMapper.java
@@ -9,9 +9,7 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.UncheckedIOException;
+import java.io.InputStream;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,14 +17,14 @@ import java.util.List;
 public class ListObjectsV2ResponseMapper implements ResponseMapper<ListObjectsV2Response> {
 
     @Override
-    public ListObjectsV2Response apply(final byte[] bytes) {
+    public ListObjectsV2Response apply(final InputStream is) {
         final XMLInputFactory factory = ResponseMapper.newFactory().get();
 
         ListObjectsV2Response.Builder response = null;
         final List<CommonPrefix> commonPrefixes = new ArrayList<>();
         final List<S3Object> contents = new ArrayList<>();
 
-        try (final ByteArrayInputStream bais = new ByteArrayInputStream(bytes)) {
+        try {
             CommonPrefix.Builder commonPrefix = null;
             S3Object.Builder s3Object = null;
             Owner.Builder owner = null;
@@ -41,7 +39,7 @@ public class ListObjectsV2ResponseMapper implements ResponseMapper<ListObjectsV2
             bKey = bLastModified = bETag = bOwner = bSize = bStorageClass = false;
             bDisplayName = bID = false;
 
-            final XMLStreamReader reader = factory.createXMLStreamReader(bais);
+            final XMLStreamReader reader = factory.createXMLStreamReader(is);
             while (reader.hasNext()) {
                 switch (reader.next()) {
                     case XMLStreamConstants.START_ELEMENT:
@@ -281,8 +279,6 @@ public class ListObjectsV2ResponseMapper implements ResponseMapper<ListObjectsV2
                 .commonPrefixes(commonPrefixes)
                 .contents(contents)
                 .build();
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
         } catch (final XMLStreamException e) {
             throw new RuntimeException(e);
         }

--- a/core/src/main/java/io/github/linktosriram/s3lite/core/mapper/ResponseMapper.java
+++ b/core/src/main/java/io/github/linktosriram/s3lite/core/mapper/ResponseMapper.java
@@ -1,6 +1,7 @@
 package io.github.linktosriram.s3lite.core.mapper;
 
 import javax.xml.stream.XMLInputFactory;
+import java.io.InputStream;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -13,7 +14,7 @@ import static javax.xml.stream.XMLInputFactory.IS_COALESCING;
  * @param <T> the type of POJO
  */
 @FunctionalInterface
-public interface ResponseMapper<T> extends Function<byte[], T> {
+public interface ResponseMapper<T> extends Function<InputStream, T> {
 
     static Supplier<XMLInputFactory> newFactory() {
         return () -> {


### PR DESCRIPTION
Hi,
this pull request fixes the parsing of the owner data in ListObjectsV2Response. DisplayName and Id where always null because their if-else cases could not be reached.  
Additionally it implements streaming parsing for ListObjectsV2Response. But I did not verify if this is really better, it could be that buffering the listing is faster. So feel free to drop the 2aa95dc412f02449d89fec8f8de893a874eb992b commit.