### PR TITLE
Build/distribution changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 jdk:
-  - openjdk8
+  - openjdk11

--- a/api/src/main/java/io/github/linktosriram/s3lite/api/exception/ErrorResponse.java
+++ b/api/src/main/java/io/github/linktosriram/s3lite/api/exception/ErrorResponse.java
@@ -1,57 +1,45 @@
 package io.github.linktosriram.s3lite.api.exception;
 
-import jakarta.xml.bind.annotation.XmlElement;
-import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Objects;
 
 /**
  * Reference: https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
  */
-@XmlRootElement(name = "Error")
 public class ErrorResponse {
 
-    private String code;
+    private final String code;
 
-    private String message;
+    private final String message;
 
-    private String requestId;
+    private final String requestId;
 
-    private String hostId;
+    private final String resource;
 
-    @XmlElement(name = "Code", required = true)
+    private ErrorResponse(final Builder builder) {
+        this.code = builder.code;
+        this.message = builder.message;
+        this.requestId = builder.requestId;
+        this.resource = builder.resource;
+    }
+
     public String getCode() {
         return code;
     }
 
-    public void setCode(final String code) {
-        this.code = code;
-    }
-
-    @XmlElement(name = "Message", required = true)
     public String getMessage() {
         return message;
     }
 
-    public void setMessage(final String message) {
-        this.message = message;
-    }
-
-    @XmlElement(name = "RequestId", required = true)
     public String getRequestId() {
         return requestId;
     }
 
-    public void setRequestId(final String requestId) {
-        this.requestId = requestId;
+    public String getResource() {
+        return resource;
     }
 
-    @XmlElement(name = "HostId", required = true)
-    public String getHostId() {
-        return hostId;
-    }
-
-    public void setHostId(final String hostId) {
-        this.hostId = hostId;
+    public static Builder builder() {
+        return new Builder();
     }
 
     @Override
@@ -62,12 +50,12 @@ public class ErrorResponse {
         return Objects.equals(code, that.code) &&
             Objects.equals(message, that.message) &&
             Objects.equals(requestId, that.requestId) &&
-            Objects.equals(hostId, that.hostId);
+            Objects.equals(resource, that.resource);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(code, message, requestId, hostId);
+        return Objects.hash(code, message, requestId, resource);
     }
 
     @Override
@@ -76,7 +64,45 @@ public class ErrorResponse {
             "code='" + code + '\'' +
             ", message='" + message + '\'' +
             ", requestId='" + requestId + '\'' +
-            ", hostId='" + hostId + '\'' +
+            ", resource='" + resource + '\'' +
             '}';
+    }
+
+    public static class Builder {
+
+        private String code;
+
+        private String message;
+
+        private String requestId;
+
+        private String resource;
+
+        private Builder() {
+        }
+
+        public Builder code(final String code) {
+            this.code = code;
+            return this;
+        }
+
+        public Builder message(final String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder requestId(final String requestId) {
+            this.requestId = requestId;
+            return this;
+        }
+
+        public Builder resource(final String resource) {
+            this.resource = resource;
+            return this;
+        }
+
+        public ErrorResponse build() {
+            return new ErrorResponse(this);
+        }
     }
 }

--- a/api/src/main/java/io/github/linktosriram/s3lite/api/exception/S3Exception.java
+++ b/api/src/main/java/io/github/linktosriram/s3lite/api/exception/S3Exception.java
@@ -6,13 +6,13 @@ public class S3Exception extends RuntimeException {
 
     private final String requestId;
 
-    private final String hostId;
+    private final String resource;
 
     public S3Exception(final ErrorResponse errorResponse) {
         super(errorResponse.getMessage());
         code = errorResponse.getCode();
         requestId = errorResponse.getRequestId();
-        hostId = errorResponse.getHostId();
+        resource = errorResponse.getResource();
     }
 
     public String getCode() {
@@ -23,7 +23,7 @@ public class S3Exception extends RuntimeException {
         return requestId;
     }
 
-    public String getHostId() {
-        return hostId;
+    public String getResource() {
+        return resource;
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 allprojects {
     apply plugin: 'java-library'
+    apply plugin: 'maven-publish'
 
     sourceCompatibility = JavaVersion.VERSION_11
 
@@ -17,6 +18,18 @@ allprojects {
     dependencies {
         testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
         testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+    }
+
+    java {
+        withSourcesJar()
+    }
+
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                from components.java
+            }
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,10 @@
 allprojects {
     apply plugin: 'java-library'
 
+    sourceCompatibility = JavaVersion.VERSION_11
+
     group = "io.github.linktosriram.s3lite"
     version = "0.0.2-SNAPSHOT"
-
-    java {
-        toolchain {
-            languageVersion = JavaLanguageVersion.of(8)
-            vendor = JvmVendorSpec.AMAZON
-        }
-    }
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ allprojects {
 project(':api') {
     dependencies {
         api project(':http-client-spi')
-        api 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
     }
 }
 
@@ -37,7 +36,7 @@ project(':core') {
 project(':http-client-apache') {
     dependencies {
         api project(':http-client-spi')
-        api 'org.apache.httpcomponents:httpclient:4.5.13'
+        api 'org.apache.httpcomponents:httpclient:4.5.14'
     }
 }
 

--- a/core/src/main/java/io/github/linktosriram/s3lite/core/mapper/ErrorResponseMapper.java
+++ b/core/src/main/java/io/github/linktosriram/s3lite/core/mapper/ErrorResponseMapper.java
@@ -1,0 +1,83 @@
+package io.github.linktosriram.s3lite.core.mapper;
+
+import io.github.linktosriram.s3lite.api.exception.ErrorResponse;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.InputStream;
+
+public class ErrorResponseMapper implements ResponseMapper<ErrorResponse> {
+
+    @Override
+    public ErrorResponse apply(final InputStream is) {
+        final XMLInputFactory factory = ResponseMapper.newFactory().get();
+
+        ErrorResponse.Builder errorResponse = null;
+        boolean bCode, bMessage, bRequestId, bResource;
+        bCode = bMessage = bRequestId = bResource = false;
+
+        try {
+            final XMLStreamReader reader = factory.createXMLStreamReader(is);
+            while (reader.hasNext()) {
+                switch (reader.next()) {
+                    case XMLStreamConstants.START_ELEMENT:
+                        switch (reader.getLocalName()) {
+                            case "Error":
+                                errorResponse = ErrorResponse.builder();
+                                break;
+                            case "Code":
+                                bCode = true;
+                                break;
+                            case "Message":
+                                bMessage = true;
+                                break;
+                            case "RequestId":
+                                bRequestId = true;
+                                break;
+                            case "Resource":
+                                bResource = true;
+                                break;
+                        }
+                        break;
+                    case XMLStreamConstants.CHARACTERS:
+                        if (errorResponse != null) {
+                            if (bCode) {
+                                errorResponse.code(reader.getText());
+                            } else if (bMessage) {
+                                errorResponse.message(reader.getText());
+                            } else if (bRequestId) {
+                                errorResponse.requestId(reader.getText());
+                            } else if (bResource) {
+                                errorResponse.resource(reader.getText());
+                            }
+                        }
+                        break;
+                    case XMLStreamConstants.END_ELEMENT:
+                        switch (reader.getLocalName()) {
+                            case "Code":
+                                bCode = false;
+                                break;
+                            case "Message":
+                                bMessage = false;
+                                break;
+                            case "RequestId":
+                                bRequestId = false;
+                                break;
+                            case "Resource":
+                                bResource = false;
+                                break;
+                        }
+                        break;
+                    case XMLStreamConstants.END_DOCUMENT:
+                        reader.close();
+                }
+            }
+        } catch (XMLStreamException e) {
+            throw new RuntimeException(e);
+        }
+
+        return errorResponse != null ? errorResponse.build() : null;
+    }
+}

--- a/core/src/main/java/io/github/linktosriram/s3lite/core/mapper/ResponseMapper.java
+++ b/core/src/main/java/io/github/linktosriram/s3lite/core/mapper/ResponseMapper.java
@@ -4,8 +4,11 @@ import javax.xml.stream.XMLInputFactory;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static javax.xml.stream.XMLInputFactory.IS_COALESCING;
+import static javax.xml.stream.XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES;
+import static javax.xml.stream.XMLInputFactory.SUPPORT_DTD;
 
 /**
  * Maps the bytes from XML response to a POJO using the Cursor based StAX API.
@@ -19,6 +22,8 @@ public interface ResponseMapper<T> extends Function<byte[], T> {
         return () -> {
             final XMLInputFactory factory = XMLInputFactory.newInstance();
             factory.setProperty(IS_COALESCING, TRUE);
+            factory.setProperty(SUPPORT_DTD, FALSE);
+            factory.setProperty(IS_SUPPORTING_EXTERNAL_ENTITIES, FALSE);
             return factory;
         };
     }


### PR DESCRIPTION
Hi,
this pull request contains additional changes I had to make to use this lib. I can understand if you do not want to include them, but I think other people would also benefit from them.

I had to remove the amazon jdk requirement, to use it with temurin jdks. This seems very strict and there is nothing in the lib that really depends on the amazon jdk.  
I also used that to bump the jdk version to 11 since 8 is EoL. Which is arbitrary strict on my part, jdk 8 would work fine too :)

Then I removed the dependency on jakarta.xml.bind-api by rewriting the ErrorResponse parsing to also just use the javax.xml.stream classes. I think this improves interoperability because it does not force jaxb version 3.
This change depends on commit 2aa95dc412f02449d89fec8f8de893a874eb992b from #14, but could easily be adapted to also work without it.

The last thing I did was add the maven-publish plugin, so the project can be easily build and used with https://jitpack.io. With this you do not have to publish to maven central for people to easily use it.